### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/EP16website/content/home.md
+++ b/EP16website/content/home.md
@@ -19,11 +19,11 @@ The practicals require [R](https://cran.r-project.org/) and
 use the following R packages:
 (JAGS (and **rjags**) are only necessary for the parts of the practical that use the **JointAI** package.)
 
-* [mice](https://cran.r-project.org/web/packages/mice) (version 3.4.0)
-* [miceadds](https://cran.r-project.org/web/packages/miceadds) (version 3.2-48)
-* [mitools](https://cran.r-project.org/web/packages/mitools) (version 2.3)
-* [JointAI](https://cran.r-project.org/web/packages/JointAI) (version 0.5.1)
-* [rjags](https://cran.r-project.org/web/packages/rjags) (version 4-8)
+* [mice](https://cran.r-project.org/package=mice) (version 3.4.0)
+* [miceadds](https://cran.r-project.org/package=miceadds) (version 3.2-48)
+* [mitools](https://cran.r-project.org/package=mitools) (version 2.3)
+* [JointAI](https://cran.r-project.org/package=JointAI) (version 0.5.1)
+* [rjags](https://cran.r-project.org/package=rjags) (version 4-8)
 
 For **JointAI** it is suggested to use the most recent version available on GitHub
 ```r

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The practicals require [R](https://cran.r-project.org/) and
 and use the following packages:
 (JAGS (and **rjags**) are only necessary for the parts of the practical that use the **JointAI** package.)
 
-* [mice](https://cran.r-project.org/web/packages/mice) (version 3.4.0)
-* [miceadds](https://cran.r-project.org/web/packages/miceadds) (version 3.2-48)
-* [mitools](https://cran.r-project.org/web/packages/mitools) (version 2.3)
-* [JointAI](https://cran.r-project.org/web/packages/JointAI) (version 0.5.1)
-* [rjags](https://cran.r-project.org/web/packages/rjags) (version 4-8)
+* [mice](https://cran.r-project.org/package=mice) (version 3.4.0)
+* [miceadds](https://cran.r-project.org/package=miceadds) (version 3.2-48)
+* [mitools](https://cran.r-project.org/package=mitools) (version 2.3)
+* [JointAI](https://cran.r-project.org/package=JointAI) (version 0.5.1)
+* [rjags](https://cran.r-project.org/package=rjags) (version 4-8)
 
 For **JointAI** it is suggested to use the most recent version available on GitHub
 ```r

--- a/Slides/03_WhenMICEfails.Rnw
+++ b/Slides/03_WhenMICEfails.Rnw
@@ -1042,7 +1042,7 @@ obtained directly
 \subsection{R package smcfcs}
 \begin{frame}{\thesection. \insertsection}
 \framesubtitle{\thesection.\thesubsection. \insertsubsection}
-\href{https://cran.r-project.org/web/packages/smcfcs/index.html}{\blue{Substantive Model Compatible Fully Conditional Specification}},\\
+\href{https://cran.r-project.org/package=smcfcs}{\blue{Substantive Model Compatible Fully Conditional Specification}},\\
 a hybrid approach between FCS and sequential factorization \cite{Bartlett2015}
 
 \bigskip
@@ -1071,7 +1071,7 @@ while ensuring compatibility between analysis model and imputation models.
 \bigskip
 
 For more information see the help files and the
-\href{https://cran.r-project.org/web/packages/smcfcs/vignettes/smcfcs-vignette.html}%
+\href{https://cran.r-project.org/package=smcfcs/vignettes/smcfcs-vignette.html}%
 {vignette}.
 \end{frame}
 
@@ -1146,7 +1146,7 @@ For more information see the help files and the
 \subsection{R package jomo}
 \begin{frame}{\thesection. \insertsection}
 \framesubtitle{\thesection.\thesubsection. \insertsubsection}
-\href{https://cran.r-project.org/web/packages/jomo/index.html}{\blue{JOint MOdel imputation}} using the multivariate normal approach,\\
+\href{https://cran.r-project.org/package=jomo}{\blue{JOint MOdel imputation}} using the multivariate normal approach,\\
 with \blue{extensions to assure compatibility} between analysis and imputation models. \cite{Carpenter2012}
 
 \bigskip
@@ -1162,7 +1162,7 @@ with \blue{extensions to assure compatibility} between analysis and imputation m
 \item Cox proportional hazards models.
 \end{itemize}
 
-For more info see the \href{https://cran.r-project.org/web/packages/jomo/jomo.pdf}{help file}.
+For more info see the \href{https://cran.r-project.org/package=jomo}{help file}.
 \end{frame}
 
 
@@ -1243,7 +1243,7 @@ For more info see the \href{https://cran.r-project.org/web/packages/jomo/jomo.pd
 \begin{frame}[fragile]{\thesection. \insertsection}
 \framesubtitle{\thesection.\thesubsection. \insertsubsection}
 
-\href{https://cran.r-project.org/web/packages/JointAI/index.html}{\blue{Joint Analysis and Imputation}}, \\
+\href{https://cran.r-project.org/package=JointAI}{\blue{Joint Analysis and Imputation}}, \\
 uses the \blue{sequential factorization approach} to perform
 simultaneous analysis and imputation. \cite{Erler2016, Erler2017}
 

--- a/docs/home/index.html
+++ b/docs/home/index.html
@@ -234,11 +234,11 @@ use the following R packages:
 (JAGS (and <strong>rjags</strong>) are only necessary for the parts of the practical that use the <strong>JointAI</strong> package.)</p>
 
 <ul>
-<li><a href="https://cran.r-project.org/web/packages/mice">mice</a> (version 3.4.0)</li>
-<li><a href="https://cran.r-project.org/web/packages/miceadds">miceadds</a> (version 3.2-48)</li>
-<li><a href="https://cran.r-project.org/web/packages/mitools">mitools</a> (version 2.3)</li>
-<li><a href="https://cran.r-project.org/web/packages/JointAI">JointAI</a> (version 0.5.1)</li>
-<li><a href="https://cran.r-project.org/web/packages/rjags">rjags</a> (version 4-8)</li>
+<li><a href="https://cran.r-project.org/package=mice">mice</a> (version 3.4.0)</li>
+<li><a href="https://cran.r-project.org/package=miceadds">miceadds</a> (version 3.2-48)</li>
+<li><a href="https://cran.r-project.org/package=mitools">mitools</a> (version 2.3)</li>
+<li><a href="https://cran.r-project.org/package=JointAI">JointAI</a> (version 0.5.1)</li>
+<li><a href="https://cran.r-project.org/package=rjags">rjags</a> (version 4-8)</li>
 </ul>
 
 <p>For <strong>JointAI</strong> it is suggested to use the most recent version available on GitHub</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -237,11 +237,11 @@ use the following R packages:
 (JAGS (and <strong>rjags</strong>) are only necessary for the parts of the practical that use the <strong>JointAI</strong> package.)</p>
 
 <ul>
-<li><a href="https://cran.r-project.org/web/packages/mice">mice</a> (version 3.4.0)</li>
-<li><a href="https://cran.r-project.org/web/packages/miceadds">miceadds</a> (version 3.2-48)</li>
-<li><a href="https://cran.r-project.org/web/packages/mitools">mitools</a> (version 2.3)</li>
-<li><a href="https://cran.r-project.org/web/packages/JointAI">JointAI</a> (version 0.5.1)</li>
-<li><a href="https://cran.r-project.org/web/packages/rjags">rjags</a> (version 4-8)</li>
+<li><a href="https://cran.r-project.org/package=mice">mice</a> (version 3.4.0)</li>
+<li><a href="https://cran.r-project.org/package=miceadds">miceadds</a> (version 3.2-48)</li>
+<li><a href="https://cran.r-project.org/package=mitools">mitools</a> (version 2.3)</li>
+<li><a href="https://cran.r-project.org/package=JointAI">JointAI</a> (version 0.5.1)</li>
+<li><a href="https://cran.r-project.org/package=rjags">rjags</a> (version 4-8)</li>
 </ul>
 
 <p>For <strong>JointAI</strong> it is suggested to use the most recent version available on GitHub</p>


### PR DESCRIPTION
[CRAN asks to use the URL variant](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.
